### PR TITLE
Add support for animated gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Spigot-Maps
 
-[![Release](https://jitpack.io/v/User/Repo.svg)] 
+![Release](https://jitpack.io/v/JohnnyJayJay/spigot-maps.svg)
+
 [JavaDoc](https://javadoc.jitpack.io/com/github/johnnyjayjay/spigot-maps/1.0/javadoc/index.html)
 
 A small library that makes the use of customised maps in Spigot very easy.
 
 ## Features
 - Dynamic map rendering (based on render context)
-- Text and image rendering with convenient usage
+- Text, image and animated gif rendering with convenient usage
 - Base class for own renderer implementations
 - API to store renderers persistently
 - Tools to resize / crop / divide images so that they fit the minecraft maps

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small library that makes the use of customised maps in Spigot very easy.
 
 ## Features
 - Dynamic map rendering (based on render context)
-- Text, image and animated gif rendering with convenient usage
+- (Animated) Text, image and animated gif rendering with convenient usage
 - Base class for own renderer implementations
 - API to store renderers persistently
 - Tools to resize / crop / divide images so that they fit the minecraft maps
@@ -68,7 +68,7 @@ ImageRenderer catRenderer = ImageRenderer.builder()
         .build(); // build the instance
 
 Dimension mapSize = ImageTools.MINECRAFT_MAP_SIZE; // the dimensions of a Minecraft map (in pixels)
-TextRenderer messageRenderer = TextRenderer.builder()
+SimpleTextRenderer messageRenderer = SimpleTextRenderer.builder()
         .addLines("Cats", "are", "so", "cute") // set the lines that will be drawn onto the map
         .addPlayers(player1, player2)
         .font(myFont) // set a text font
@@ -85,6 +85,19 @@ ItemStack mapItem = map.createItemStack(); // get an ItemStack from this map to 
 ```
 
 This example would result in a map that has an image of a cat in the background and the text "Cats are so cute" in the foreground.
+
+You can still mutate the renderers afterwards:
+```java
+messageRenderer.setText("Cats\nare\nstill\ncute");
+```
+Note that this will only have effect if `renderOnce` is set to true while building. 
+The reason for that decision is performance. Only rendering once saves resources, but 
+disables later modification.
+If you want to mutate a renderer after building but then leave it that way, you may call
+```java
+messageRenderer.stopRendering();
+```
+to save the resources.
 
 ### Quicker ways
 
@@ -107,7 +120,7 @@ See `ImageTools.createSingleColoredImage(Color)` to get an instance of `Buffered
 **Create a TextRenderer with just some lines of text**:
 
 ```java
-TextRenderer renderer = TextRenderer.create("This", "is", "noice");
+SimpleTextRenderer renderer = SimpleTextRenderer.create("This", "is", "noice");
 ```
 
 **Create a RenderedMap with just some MapRenderers**:
@@ -118,33 +131,73 @@ RenderedMap map = RenderedMap.create(renderer1, renderer2); // not providing any
 
 ### Advanced
 
-Images that take more than 1 map to display can be created using `ImageTools.resizeIntoMapSizedParts(BufferedImage, boolean)`. This uses an algorithm that makes a square version of the image first. How this is done can be determined via the second `boolean` parameter. If it is set to `true`, a square cropped out from the middle of the image will be used. If it is `false`, the whole image will be resized to 1:1.
+#### Gifs 
+
+This library can handle animated gifs using `GifRenderer` and `GifImage`.
+Instances of `GifImage` can be obtained via an instance of `GifDecoder` from this library's dependencies:
+```java
+GifDecoder decoder = new GifDecoder();
+decoder.read("./example.gif"); // this also works with URLs, InputStreams etc.
+GifImage gif = GifImage.fromDecoder(decoder);
+```
+For more info about `GifDecoder`, look at [this](https://github.com/rtyley/animated-gif-lib-for-java).
+
+You can also implement an algorithm to decode gifs yourself and then make use of `GifImage#create(List<Frame>)`.
+
+`GifRenderer`s are created like any other renderer:
+```java
+GifRenderer renderer = GifRenderer.builder()
+        .gif(gif) // set the GifImage we just created
+        .repeat(5) // repeat the gif 5 times: to repeat it indefinitely, omit this setting or set it to GifRenderer.REPEAT_FOREVER
+        .build();
+```
+This renderer stops rendering automatically after 5 repetitions and 
+can now be added to a `MapView` / `RenderedMap` as shown above.
+
+#### Animated Text
+
+Text doesn't have to be static. This library provides a map renderer that renders text character by character.
+```java
+AnimatedTextRenderer renderer = AnimatedTextRenderer.builder()
+        .addText("This text will appear char by char.")
+        .charsPerSecond(10) // 10 characters should appear each second
+        .delay(20) // start the animation after 20 ticks (1 second)
+        .build();
+```
+This renderer automatically stops rendering after having finished.
+
+#### Splitting images
+
+Images that take more than 1 map to display can be created using `ImageTools.divideIntoMapSizedParts(BufferedImage, boolean)`.
+This uses an algorithm that makes a square version of the image first. How this is done can be determined via the second 
+`boolean` parameter. If it is set to `true`, a square cropped out from the middle of the image will be used 
+(if the image is big enough). If it is `false`, the whole image will be resized to 1:1.
 
 ```java
-BufferedImage[][] parts = ImageTools.resizeIntoMapSizedParts(image, true);
+List<BufferedImage> parts = ImageTools.divideIntoMapSizedParts(image, true);
 ```
+
+**The exact same methods are available to `GifImage`s.**
 
 To turn these into map items:
 
 ```java
-ItemStack[][] maps = Arrays.stream(parts).map(
-        (part) -> Arrays.stream(part)
-                .map(ImageRenderer::create)
-                .map(RenderedMap::create)
-                .map(RenderedMap::createItemStack)
-                .toArray(ItemStack[]::new)
-).toArray(ItemStack[][]::new);
-```
-
-This results in the same as:
-
-```java
-ItemStack[][] maps = new ItemStack[parts.length][];
-for (int row = 0; row < parts.length; row++) {
-    for (int column = 0; column < parts[row].length, column++) {
-        maps[row][column] = RenderedMap.create(ImageRenderer
-                .create(parts[row][column]))
-                .createItemStack();
-    }
+for (BufferedImage part : parts) {
+    ImageRenderer renderer = ImageRenderer.create(part);
+    ItemStack mapItem = RenderedMap.create(renderer).createItemStack();
+    // do something with it
 }
 ```
+
+Or, if you want to do it stream-like:
+```java
+parts.stream()
+        .map(ImageRenderer::create)
+        .map(RenderedMap::create)
+        .map(RenderedMap::createItemStack)
+        .forEach((mapItem) -> {
+    // do something with it
+})
+```
+
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Release](https://jitpack.io/v/JohnnyJayJay/spigot-maps.svg)
 
-[JavaDoc](https://javadoc.jitpack.io/com/github/johnnyjayjay/spigot-maps/1.0/javadoc/index.html)
+[JavaDoc](https://javadoc.jitpack.io/com/github/johnnyjayjay/spigot-maps/1.1/javadoc/index.html)
 
 A small library that makes the use of customised maps in Spigot very easy.
 
@@ -200,4 +200,26 @@ parts.stream()
 })
 ```
 
+#### Using MapStorage
 
+The `MapStorage` API makes it possible to save renderers persistently. To utilise it, you have to implement MapStorage:
+
+```java
+public class FileStorage implements MapStorage {
+
+    @Override
+    public void store(int id, MapRenderer renderer) {
+        // serialize the renderer associated with the given id
+    }
+    
+    @Override
+    public boolean remove(int id, MapRenderer renderer) {
+        // remove the given renderer's association with the given id
+    }
+    
+    @Override
+    public List<MapRenderer> provide(int id) {
+        // fetch / deserialize / read all renderers stored for the given id
+    }
+}
+```

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     compileOnly "org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT"
+    compile "com.madgag:animated-gif-lib:1.4"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.github.johnnyjayjay'
-version '1.0'
+version '1.1'
 
 sourceCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'maven'
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
 }
 
 group 'com.github.johnnyjayjay'
@@ -36,6 +37,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 artifacts {
     archives sourcesJar
     archives javadocJar
+    archives shadowJar
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+shadowJar.classifier = "withDependencies"
+
 artifacts {
     archives sourcesJar
     archives javadocJar

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/Checks.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/Checks.java
@@ -1,7 +1,6 @@
 package com.github.johnnyjayjay.spigotmaps;
 
 import java.awt.Point;
-import java.util.Collection;
 
 /**
  * internal class
@@ -26,16 +25,14 @@ public final class Checks {
             throw new AssertionError("Unexpected null value");
     }
 
-    public static void checkNotEmpty(Collection<?> collection, String name) {
-        check(!collection.isEmpty(), name + " must not be empty");
+    public static void checkStartingPoint(Point startingPoint) {
+        checkNotNull(startingPoint, "Starting point");
+        checkBounds(startingPoint.x, 0, ImageTools.MINECRAFT_MAP_SIZE.width, "Starting point");
+        checkBounds(startingPoint.y, 0, ImageTools.MINECRAFT_MAP_SIZE.height, "Starting point");
     }
 
-    public static void checkStartingPoint(Point point) {
-        Checks.checkNotNull(point, "Starting point");
-        Checks.check(point.x >= 0 && point.y >= 0, "Negative coordinates are not allowed");
-        Checks.check(point.x <= ImageTools.MINECRAFT_MAP_SIZE.width
-                        && point.y <= ImageTools.MINECRAFT_MAP_SIZE.height,
-                "Starting point is out of minecraft map bounds");
+    public static void checkBounds(int number, int startInclusive, int endExclusive, String name) {
+        check(number >= startInclusive && number < endExclusive, name + " out of bounds");
     }
 
 }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/ImageTools.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/ImageTools.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.net.URLConnection;
 
 /**
+ * TODO convenience methods for gifs
  * A utility class containing several methods to adjust and get images fitting the Minecraft map format.
  *
  * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/ImageTools.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/ImageTools.java
@@ -89,7 +89,7 @@ public final class ImageTools {
      * @return a never-null 2-dimensional array of images. The outer index represents a row, the inner
      *         one a column in the square arrangement of parts.
      */
-    public static BufferedImage[][] resizeIntoMapSizedParts(BufferedImage image, boolean crop) {
+    public static BufferedImage[][] divideIntoMapSizedParts(BufferedImage image, boolean crop) {
         return divideIntoParts(crop ? cropToMapDividableSquare(image) : scaleToMapDividableSquare(image));
     }
 

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/MapBuilder.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/MapBuilder.java
@@ -3,6 +3,7 @@ package com.github.johnnyjayjay.spigotmaps;
 import com.github.johnnyjayjay.spigotmaps.rendering.AbstractMapRenderer;
 import com.github.johnnyjayjay.spigotmaps.rendering.ImageRenderer;
 import com.github.johnnyjayjay.spigotmaps.rendering.TextRenderer;
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.map.MapRenderer;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/MapBuilder.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/MapBuilder.java
@@ -2,7 +2,7 @@ package com.github.johnnyjayjay.spigotmaps;
 
 import com.github.johnnyjayjay.spigotmaps.rendering.AbstractMapRenderer;
 import com.github.johnnyjayjay.spigotmaps.rendering.ImageRenderer;
-import com.github.johnnyjayjay.spigotmaps.rendering.TextRenderer;
+import com.github.johnnyjayjay.spigotmaps.rendering.SimpleTextRenderer;
 import com.github.johnnyjayjay.spigotmaps.util.Checks;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -75,7 +75,7 @@ public class MapBuilder {
      *
      * @see AbstractMapRenderer
      * @see ImageRenderer
-     * @see TextRenderer
+     * @see SimpleTextRenderer
      * @param renderers A non-null list of renderers.
      * @return this.
      */

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/RenderedMap.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/RenderedMap.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
@@ -186,13 +187,28 @@ public class RenderedMap implements MapView {
 
     /**
      * Creates and returns an {@link ItemStack} of the type {@code Material.MAP} associated with this instance's
-     * underlying {@link MapView}.
+     * underlying {@link MapView} and no further metadata.
      *
-     * @return a freshly created, never-{@code null} ItemStack.
+     * @return a never-{@code null} ItemStack.
+     * @see #createItemStack(String, String...)
      */
     public ItemStack createItemStack() {
+        return createItemStack(null);
+    }
+
+    /**
+     * Creates and returns an {@link ItemStack} of the type {@code Material.MAP} associated with this instance's
+     * underlying {@link MapView}.
+     *
+     * @param displayName the display name of the result.
+     * @param lore the lore of the result or nothing, if there shouldn't be lore.
+     * @return a new ItemStack.
+     */
+    public ItemStack createItemStack(String displayName, String... lore) {
         MapMeta mapMeta = (MapMeta) Bukkit.getItemFactory().getItemMeta(Material.MAP);
         mapMeta.setMapView(view);
+        mapMeta.setDisplayName(displayName);
+        mapMeta.setLore(lore.length == 0 ? null : Arrays.asList(lore));
         ItemStack itemStack = new ItemStack(Material.MAP);
         itemStack.setItemMeta(mapMeta);
         return itemStack;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
  *
  * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
  * @see ImageRenderer
- * @see TextRenderer
+ * @see SimpleTextRenderer
  */
 public abstract class AbstractMapRenderer extends MapRenderer {
 
@@ -137,6 +137,15 @@ public abstract class AbstractMapRenderer extends MapRenderer {
     }
 
     /**
+     * Returns whether this renderer has stopped rendering as a result to a call to {@link #stopRendering()}.
+     *
+     * @return {@code true}, if it has stopped.
+     */
+    public boolean isStopped() {
+        return stop;
+    }
+
+    /**
      * Renders the map after the preconditions have passed, i.e.:
      * <ul>
      * <li>This renderer applies to the player or</li>
@@ -179,7 +188,7 @@ public abstract class AbstractMapRenderer extends MapRenderer {
          * Checks whether the precondition is null or the starting point doesn't fit the minecraft map size.
          * Should be called before building instances of {@link AbstractMapRenderer}.
          */
-        protected final void check() {
+        protected void check() {
             Checks.checkNotNull(precondition, "Precondition");
             Checks.checkStartingPoint(startingPoint);
         }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
@@ -1,13 +1,13 @@
 package com.github.johnnyjayjay.spigotmaps.rendering;
 
-import com.github.johnnyjayjay.spigotmaps.Checks;
-import com.github.johnnyjayjay.spigotmaps.ImageTools;
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
+import com.github.johnnyjayjay.spigotmaps.util.ImageTools;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 
-import java.awt.*;
+import java.awt.Point;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
@@ -167,7 +167,7 @@ public abstract class AbstractMapRenderer extends MapRenderer {
      * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
      */
     @SuppressWarnings("unchecked")
-    protected static abstract class Builder<T, U extends Builder<T, U>> {
+    protected static abstract class Builder<T extends AbstractMapRenderer, U extends Builder<T, U>> {
 
         protected final Set<Player> receivers = new HashSet<>();
         protected Predicate<RenderContext> precondition = (ctx) -> true;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AbstractMapRenderer.java
@@ -176,7 +176,8 @@ public abstract class AbstractMapRenderer extends MapRenderer {
         public abstract T build();
 
         /**
-         * Checks whether the precondition is null. Should be called when building instances of {@link AbstractMapRenderer}.
+         * Checks whether the precondition is null or the starting point doesn't fit the minecraft map size.
+         * Should be called before building instances of {@link AbstractMapRenderer}.
          */
         protected final void check() {
             Checks.checkNotNull(precondition, "Precondition");

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AnimatedTextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AnimatedTextRenderer.java
@@ -39,6 +39,17 @@ public class AnimatedTextRenderer extends TextRenderer {
         this.ticksToWait = tickDelay + 1;
     }
 
+    private double calculateTicksToWait() {
+        double charsPerTick = charsPerSecond / 20D;
+        return (currentChar + 1) / charsPerTick - currentChar / charsPerTick;
+    }
+
+    private int charsToAppend(double ticksToWait) {
+        return ticksToWait < 1
+                ? (int) (1 / ticksToWait)
+                : 1;
+    }
+
     @Override
     protected void render(RenderContext context) {
         if (--ticksToWait > 0)
@@ -47,9 +58,13 @@ public class AnimatedTextRenderer extends TextRenderer {
         if (currentChar >= text.length()) {
             stopRendering();
         } else {
-            renderedText.append(text.charAt(currentChar++));
+            double ticksToWait = calculateTicksToWait();
+            this.ticksToWait = ticksToWait < 1 ? 1 : Math.round(ticksToWait);
+            for (int destinationLength = charsToAppend(ticksToWait) + currentChar;
+                 currentChar < destinationLength; currentChar++) {
+                renderedText.append(text.charAt(currentChar));
+            }
             context.getCanvas().drawText(startingPoint.x, startingPoint.y, font, renderedText.toString());
-            this.ticksToWait = Math.round(Math.pow(charsPerSecond / 20D, -1));
         }
     }
 

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AnimatedTextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/AnimatedTextRenderer.java
@@ -1,0 +1,141 @@
+package com.github.johnnyjayjay.spigotmaps.rendering;
+
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
+import org.bukkit.entity.Player;
+import org.bukkit.map.MapFont;
+
+import java.awt.Point;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * An implementation of {@link TextRenderer} that renders texts onto a map character by character.
+ * <p>
+ * This class is not thread safe and will stop rendering automatically once the given text has fully rendered.
+ *
+ * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
+ * @see Builder
+ */
+public class AnimatedTextRenderer extends TextRenderer {
+
+    private StringBuilder renderedText;
+    private int currentChar;
+    private int charsPerSecond;
+    private long ticksToWait;
+
+    private AnimatedTextRenderer(
+            Point startingPoint,
+            Set<Player> receivers,
+            Predicate<RenderContext> precondition,
+            CharSequence text,
+            MapFont font,
+            int charsPerSecond,
+            int tickDelay
+    ) {
+        super(startingPoint, receivers, false, precondition, text, font);
+        this.charsPerSecond = charsPerSecond;
+        this.currentChar = 0;
+        this.renderedText = new StringBuilder();
+        this.ticksToWait = tickDelay + 1;
+    }
+
+    @Override
+    protected void render(RenderContext context) {
+        if (--ticksToWait > 0)
+            return;
+
+        if (currentChar >= text.length()) {
+            stopRendering();
+        } else {
+            renderedText.append(text.charAt(currentChar++));
+            context.getCanvas().drawText(startingPoint.x, startingPoint.y, font, renderedText.toString());
+            this.ticksToWait = Math.round(Math.pow(charsPerSecond / 20D, -1));
+        }
+    }
+
+    /**
+     * Returns how many characters are rendered each second by this class.
+     */
+    public int getCharsPerSecond() {
+        return charsPerSecond;
+    }
+
+    /**
+     * Sets how many characters are rendered each second.
+     *
+     * @param charsPerSecond the new amount.
+     * @throws IllegalArgumentException if the argument is not positive.
+     */
+    public void setCharsPerSecond(int charsPerSecond) {
+        Checks.check(charsPerSecond > 0, "Chars per second must be positive");
+        this.charsPerSecond = charsPerSecond;
+    }
+
+    /**
+     * Creates and returns a new instance of this class' {@link Builder}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder class used to create instances of the enclosing {@link AnimatedTextRenderer} class.
+     *
+     * @author Johnny_JayJay (https://github.com/johnnyjayjay)
+     * @see #builder()
+     */
+    public static class Builder extends TextRenderer.Builder<AnimatedTextRenderer, Builder> {
+
+        private int charsPerSecond = 20;
+        private int delay = 0;
+
+        private Builder() {
+        }
+
+        @Override
+        public AnimatedTextRenderer build() {
+            super.check();
+            Checks.check(charsPerSecond > 0, "Chars per second must be positive");
+            Checks.check(delay >= 0, "Delay must not be negative");
+            return new AnimatedTextRenderer(startingPoint, receivers, precondition, text, font, charsPerSecond, delay);
+        }
+
+        /**
+         * Sets the amount of characters that should be rendered each second.
+         * <p>
+         * This is optional. The default value is 20, i.e. 20 characters will be rendered each second.
+         *
+         * @param amount a positive int amount.
+         * @return this.
+         */
+        public Builder charsPerSecond(int amount) {
+            this.charsPerSecond = amount;
+            return this;
+        }
+
+        /**
+         * Sets a delay in ticks that should be applied to this renderer, i.e.
+         * it will delay the animation for the time of this delay at the beginning.
+         * <p>
+         * This is optional. The default value is 0, i.e. there won't be a delay.
+         *
+         * @param ticks the amount of ticks to wait (20 ticks = 1 second).
+         * @return this.
+         */
+        public Builder delay(int ticks) {
+            this.delay = ticks;
+            return this;
+        }
+
+        /**
+         * Not a supported operation, because every AnimatedTextRenderer MUST render more than once and this
+         * value can therefore not be set individually.
+         *
+         * @throws UnsupportedOperationException always.
+         */
+        @Override
+        public Builder renderOnce(boolean renderOnce) {
+            throw new UnsupportedOperationException("renderOnce is always false for AnimatedTextRenderers and thus not allowed to be set");
+        }
+    }
+}

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
@@ -1,5 +1,6 @@
 package com.github.johnnyjayjay.spigotmaps.rendering;
 
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
 import com.madgag.gif.fmsware.GifDecoder;
 
 import java.awt.image.BufferedImage;
@@ -12,7 +13,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * TODO documentation
+ * A class representing a .gif image, in particular animated ones.
+ *
+ * @see GifRenderer
  * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
  */
 public class GifImage implements Iterable<GifImage.Frame> {
@@ -23,13 +26,38 @@ public class GifImage implements Iterable<GifImage.Frame> {
         this.frames = Collections.unmodifiableList(frames);
     }
 
+    /**
+     * Creates a new {@link GifImage} based on the data of a {@link com.madgag.gif.fmsware.GifDecoder}.
+     *
+     * @param decoder a GifDecoder that contains an already read gif image.
+     * @return a new, never-{@code null} GifImage.
+     */
     public static GifImage fromDecoder(GifDecoder decoder) {
         return new GifImage(IntStream.range(0, decoder.getFrameCount())
                 .mapToObj((i) -> Frame.create(decoder.getFrame(i), decoder.getDelay(i)))
                 .collect(Collectors.toList()));
     }
 
+    /**
+     * Creates a new {@link GifImage} based on a List of Frames.
+     *
+     * @param frames a List of {@link Frame}s to be used in this gif.
+     * @return a new, never-{@code null} GifImage.
+     * @throws IllegalArgumentException if not all frames are of the same size.
+     */
     public static GifImage create(List<Frame> frames) {
+        if (frames.isEmpty())
+            return new GifImage(Collections.emptyList());
+
+        BufferedImage first = frames.get(0).getImage();
+        int width = first.getWidth();
+        int height = first.getHeight();
+        Checks.check(
+                frames.stream()
+                        .map(Frame::getImage)
+                        .allMatch((image) -> image.getWidth() == width && image.getHeight() == height),
+                "The frames must all have the same size"
+        );
         return new GifImage(frames);
     }
 
@@ -48,14 +76,29 @@ public class GifImage implements Iterable<GifImage.Frame> {
         return frames.spliterator();
     }
 
+    /**
+     * Returns the amount of frames this gif holds.
+     */
     public int getFrameCount() {
         return frames.size();
     }
 
+    /**
+     * Returns the frame at the position of the specified index.
+     *
+     * @param index the index of the {@link Frame} to retrieve.
+     * @return a never-{@code null} {@link Frame} that gives access to its image and delay.
+     * @throws IndexOutOfBoundsException if the the index is out of bounds for the list of frames.
+     */
     public Frame get(int index) {
         return frames.get(index);
     }
 
+    /**
+     * A class representing a single frame in an animated gif.
+     *
+     * @see GifImage
+     */
     public static class Frame {
         private final BufferedImage image;
         private final int msDelay;
@@ -65,14 +108,30 @@ public class GifImage implements Iterable<GifImage.Frame> {
             this.msDelay = msDelay;
         }
 
+        /**
+         * A factory method to create instances of this class.
+         *
+         * @param image the image this frame displays.
+         * @param msDelay a duration in milliseconds, i.e. how long this frame should be displayed.
+         * @return a new, never-{@code null} instance of {@link Frame}.
+         * @throws IllegalArgumentException if the given duration/delay is not positive.
+         */
         public static Frame create(BufferedImage image, int msDelay) {
+            Checks.checkNotNull(image, "Image");
+            Checks.check(msDelay > 0, "Duration must be positive");
             return new Frame(image, msDelay);
         }
 
+        /**
+         * Returns the duration in milliseconds indicating how long this particular frame should be displayed in a gif.
+         */
         public int getMsDelay() {
             return msDelay;
         }
 
+        /**
+         * Returns the image of this frame.
+         */
         public BufferedImage getImage() {
             return image;
         }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
@@ -1,0 +1,76 @@
+package com.github.johnnyjayjay.spigotmaps.rendering;
+
+import com.madgag.gif.fmsware.GifDecoder;
+
+import java.awt.image.BufferedImage;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
+ */
+public class GifImage implements Iterable<GifImage.Frame> {
+
+    private final List<Frame> frames;
+
+    private GifImage(List<Frame> frames) {
+        this.frames = Collections.unmodifiableList(frames);
+    }
+
+    public static GifImage fromDecoder(GifDecoder decoder) {
+        return new GifImage(IntStream.range(0, decoder.getFrameCount())
+                .mapToObj((i) -> Frame.create(decoder.getFrame(i), decoder.getDelay(i)))
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Iterator<Frame> iterator() {
+        return frames.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super Frame> action) {
+        frames.forEach(action);
+    }
+
+    @Override
+    public Spliterator<Frame> spliterator() {
+        return frames.spliterator();
+    }
+
+    public int getFrameCount() {
+        return frames.size();
+    }
+
+    public Frame get(int index) {
+        return frames.get(index);
+    }
+
+    public static class Frame {
+        private final BufferedImage image;
+        private final int msDelay;
+
+        private Frame(BufferedImage image, int msDelay) {
+            this.image = image;
+            this.msDelay = msDelay;
+        }
+
+        public static Frame create(BufferedImage image, int msDelay) {
+            return new Frame(image, msDelay);
+        }
+
+        public int getMsDelay() {
+            return msDelay;
+        }
+
+        public BufferedImage getImage() {
+            return image;
+        }
+    }
+
+}

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
+ * TODO documentation
  * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
  */
 public class GifImage implements Iterable<GifImage.Frame> {

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifImage.java
@@ -29,6 +29,10 @@ public class GifImage implements Iterable<GifImage.Frame> {
                 .collect(Collectors.toList()));
     }
 
+    public static GifImage create(List<Frame> frames) {
+        return new GifImage(frames);
+    }
+
     @Override
     public Iterator<Frame> iterator() {
         return frames.iterator();

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /**
+ * TODO documentation
  * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
  */
 public class GifRenderer extends AbstractMapRenderer {

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
@@ -1,0 +1,112 @@
+package com.github.johnnyjayjay.spigotmaps.rendering;
+
+import com.github.johnnyjayjay.spigotmaps.Checks;
+import org.bukkit.entity.Player;
+
+import java.awt.Point;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
+ */
+public class GifRenderer extends AbstractMapRenderer {
+
+    public static final int REPEAT_FOREVER = -1;
+
+    private final GifImage image;
+
+    private int currentFrame;
+    private int toRepeat;
+    private int ticksToWait;
+
+    private GifRenderer(
+            Point startingPoint,
+            Set<Player> receivers,
+            Predicate<RenderContext> precondition,
+            GifImage image,
+            int startFrame,
+            int repeat
+    ) {
+        super(startingPoint, receivers, false, precondition);
+        this.image = image;
+        this.currentFrame = startFrame;
+        this.toRepeat = repeat;
+        this.ticksToWait = msToTicks(image.get(currentFrame).getMsDelay());
+    }
+
+    private int msToTicks(int millis) {
+        return millis / 1000 * 20;
+    }
+
+    @Override
+    protected void render(RenderContext context) {
+        if (ticksToWait-- > 0)
+            return;
+
+        if (currentFrame + 1 >= image.getFrameCount()) {
+            currentFrame = 0;
+            if (--toRepeat == 0) {
+                this.stopRendering();
+                return;
+            }
+        }
+
+        GifImage.Frame frame = image.get(currentFrame++);
+        context.getCanvas().drawImage(startingPoint.x, startingPoint.y, frame.getImage());
+        ticksToWait = msToTicks(frame.getMsDelay());
+    }
+
+
+    public int getToRepeat() {
+        return toRepeat;
+    }
+
+    public int getCurrentFrame() {
+        return currentFrame;
+    }
+
+    public void setFrame(int frame) {
+        Checks.checkBounds(frame, 0, image.getFrameCount(), "Frame index");
+        this.currentFrame = frame;
+    }
+
+    public static class Builder extends AbstractMapRenderer.Builder<GifRenderer, Builder> {
+
+        private GifImage gifImage = null;
+        private int startFrame = 0;
+        private int repeat = REPEAT_FOREVER;
+
+        @Override
+        public GifRenderer build() {
+            renderOnce = false;
+            super.check();
+            Checks.checkNotNull(gifImage, "GIF image");
+            Checks.checkBounds(startFrame, 0, gifImage.getFrameCount(), "Frame index");
+            return new GifRenderer(startingPoint, receivers, precondition, gifImage, startFrame, repeat);
+        }
+
+        public Builder gif(GifImage gifImage) {
+            this.gifImage = gifImage;
+            return this;
+        }
+
+        public Builder startAt(int frame) {
+            this.startFrame = frame;
+            return this;
+        }
+
+        public Builder repeat(int times) {
+            this.repeat = times;
+            return this;
+        }
+
+        /**
+         * Not a supported operation, as a GifRenderer MUST render more than once.
+         */
+        @Override
+        public Builder renderOnce(boolean renderOnce) {
+            throw new UnsupportedOperationException("renderOnce is always false for GifRenderers and thus not allowed to be set");
+        }
+    }
+}

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
@@ -20,7 +20,6 @@ import java.util.function.Predicate;
 public class ImageRenderer extends AbstractMapRenderer {
 
     private BufferedImage image;
-    private Point startingPoint;
 
     private ImageRenderer(
             Set<Player> receivers,
@@ -29,9 +28,8 @@ public class ImageRenderer extends AbstractMapRenderer {
             BufferedImage image,
             Point startingPoint
     ) {
-        super(receivers, renderOnce, precondition);
+        super(startingPoint, receivers, renderOnce, precondition);
         this.image = image;
-        this.startingPoint = startingPoint;
     }
 
     @Override
@@ -55,24 +53,6 @@ public class ImageRenderer extends AbstractMapRenderer {
     public void setImage(BufferedImage image) {
         Checks.checkNotNull(image, "Image");
         this.image = ImageTools.copyOf(image);
-    }
-
-    /**
-     * Returns a copy of the point where the renderer begins to render text on a map.
-     */
-    public Point getStartingPoint() {
-        return new Point(startingPoint);
-    }
-
-    /**
-     * Sets the point on the map where this renderer should start rendering.
-     *
-     * @param startingPoint the point to set.
-     * @throws IllegalArgumentException if the given point cannot be applied to a minecraft map or is null.
-     */
-    public void setStartingPoint(Point startingPoint) {
-        Checks.checkStartingPoint(startingPoint);
-        this.startingPoint = new Point(startingPoint);
     }
 
     /**
@@ -114,7 +94,6 @@ public class ImageRenderer extends AbstractMapRenderer {
     public static class Builder extends AbstractMapRenderer.Builder<ImageRenderer, Builder> {
 
         private BufferedImage image = null;
-        private Point startingPoint = new Point();
 
         private Builder() {
         }
@@ -135,7 +114,6 @@ public class ImageRenderer extends AbstractMapRenderer {
         @Override
         public ImageRenderer build() {
             super.check();
-            Checks.checkStartingPoint(startingPoint);
             Checks.checkNotNull(image, "Image");
             return new ImageRenderer(receivers, precondition, renderOnce, image, startingPoint);
         }
@@ -154,23 +132,6 @@ public class ImageRenderer extends AbstractMapRenderer {
          */
         public Builder image(BufferedImage image) {
             this.image = ImageTools.copyOf(image);
-            return this;
-        }
-
-        /**
-         * Sets the coordinates (via a {@link Point} determining where to begin drawing the image on the map.
-         * <p>
-         * This makes a defensive copy of the {@link Point}, so changes to the argument will not have any
-         * effect on this instance.
-         * <p>
-         * This is not required. By default, it will start drawing from the upper left corner (0, 0).
-         *
-         * @param point a non-{@code null} {@link Point} representing the coordinates, i.e. where to begin drawing.
-         * @return this.
-         * @see ImageTools#MINECRAFT_MAP_SIZE
-         */
-        public Builder startingPoint(Point point) {
-            this.startingPoint = new Point(point);
             return this;
         }
     }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
@@ -38,10 +38,10 @@ public class ImageRenderer extends AbstractMapRenderer {
     }
 
     /**
-     * Returns a copy of the {@link BufferedImage} used by this renderer.
+     * Returns the {@link BufferedImage} used by this renderer.
      */
     public BufferedImage getImage() {
-        return ImageTools.copyOf(image);
+        return image;
     }
 
     /**
@@ -52,7 +52,7 @@ public class ImageRenderer extends AbstractMapRenderer {
      */
     public void setImage(BufferedImage image) {
         Checks.checkNotNull(image, "Image");
-        this.image = ImageTools.copyOf(image);
+        this.image = image;
     }
 
     /**
@@ -121,9 +121,6 @@ public class ImageRenderer extends AbstractMapRenderer {
         /**
          * Sets the image that should be rendered onto the map by this renderer.
          * <p>
-         * This makes a defensive copy of the {@link BufferedImage}, so changes to the argument will not
-         * have any effect on this instance.
-         * <p>
          * This is a required setting.
          *
          * @param image the non-{@code null} {@link BufferedImage} to draw.
@@ -131,7 +128,7 @@ public class ImageRenderer extends AbstractMapRenderer {
          * @see ImageTools
          */
         public Builder image(BufferedImage image) {
-            this.image = ImageTools.copyOf(image);
+            this.image = image;
             return this;
         }
     }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
@@ -89,6 +89,7 @@ public class ImageRenderer extends AbstractMapRenderer {
     /**
      * A builder class used to create instances of the enclosing {@link ImageRenderer} class.
      *
+     * @see #builder()
      * @author Johnny_JayJay (https://github.com/johnnyjayjay)
      */
     public static class Builder extends AbstractMapRenderer.Builder<ImageRenderer, Builder> {

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/ImageRenderer.java
@@ -1,7 +1,7 @@
 package com.github.johnnyjayjay.spigotmaps.rendering;
 
-import com.github.johnnyjayjay.spigotmaps.Checks;
-import com.github.johnnyjayjay.spigotmaps.ImageTools;
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
+import com.github.johnnyjayjay.spigotmaps.util.ImageTools;
 import org.bukkit.entity.Player;
 
 import java.awt.Color;
@@ -99,7 +99,7 @@ public class ImageRenderer extends AbstractMapRenderer {
         }
 
         /**
-         * Creates a new {@link ImageRenderer}.
+         * Builds a new instance of {@link ImageRenderer} based on the settings made.
          *
          * @return a new instance of {@link ImageRenderer}.
          * @throws IllegalArgumentException if

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/RenderContext.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/RenderContext.java
@@ -1,6 +1,6 @@
 package com.github.johnnyjayjay.spigotmaps.rendering;
 
-import com.github.johnnyjayjay.spigotmaps.Checks;
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapView;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/SimpleTextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/SimpleTextRenderer.java
@@ -1,0 +1,81 @@
+package com.github.johnnyjayjay.spigotmaps.rendering;
+
+import org.bukkit.entity.Player;
+import org.bukkit.map.MapFont;
+
+import java.awt.Point;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * An implementation of {@link TextRenderer} that can be used to render text on a map.
+ *
+ * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
+ * @see Builder
+ */
+public class SimpleTextRenderer extends TextRenderer {
+
+    private SimpleTextRenderer(
+            Point startingPoint,
+            Set<Player> receivers,
+            Predicate<RenderContext> precondition,
+            boolean renderOnce,
+            String text,
+            MapFont font
+    ) {
+        super(startingPoint, receivers, renderOnce, precondition, text, font);
+    }
+
+    @Override
+    protected void render(RenderContext context) {
+        context.getCanvas().drawText(startingPoint.x, startingPoint.y, font, text.toString());
+    }
+
+    /**
+     * Creates a {@link SimpleTextRenderer} that renders the given lines of text onto a map.
+     *
+     * @param lines 0-n Strings or an array of Strings to use as the lines. Must not be {@code null}.
+     * @return a new, never-null instance of {@link SimpleTextRenderer}.
+     */
+    public static SimpleTextRenderer create(String... lines) {
+        return builder().addLines(lines).build();
+    }
+
+    /**
+     * Creates and returns a new instance of this class' {@link Builder}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder class used to create instances of the enclosing {@link SimpleTextRenderer} class.
+     *
+     * @author Johnny_JayJay (https://github.com/johnnyjayjay)
+     * @see #builder()
+     */
+    public static class Builder extends TextRenderer.Builder<SimpleTextRenderer, Builder> {
+
+        private Builder() {
+        }
+
+        /**
+         * Builds a new instance of {@link SimpleTextRenderer} based on the settings made.
+         *
+         * @return a never-null instance of {@link SimpleTextRenderer}.
+         * @throws IllegalArgumentException if:
+         *                                  <ul>
+         *                                  <li>The precondition is {@code null}</li>
+         *                                  <li>The font is {@code null}</li>
+         *                                  <li>The starting point is {@code null}</li>
+         *                                  <li>The starting point's coordinates are not positive</li>
+         *                                  <li>The starting point's coordinates are out of the minecraft map size bounds</li>
+         *                                  </ul>
+         */
+        @Override
+        public SimpleTextRenderer build() {
+            super.check();
+            return new SimpleTextRenderer(startingPoint, receivers, precondition, renderOnce, text.toString(), font);
+        }
+    }
+}

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
@@ -22,7 +22,6 @@ import java.util.function.Predicate;
 public class TextRenderer extends AbstractMapRenderer {
 
     private String text;
-    private Point startingPoint;
     private MapFont font;
 
     private TextRenderer(
@@ -33,9 +32,8 @@ public class TextRenderer extends AbstractMapRenderer {
             Point startingPoint,
             MapFont font
     ) {
-        super(receivers, renderOnce, precondition);
+        super(startingPoint, receivers, renderOnce, precondition);
         this.text = text;
-        this.startingPoint = startingPoint;
         this.font = font;
     }
 
@@ -49,13 +47,6 @@ public class TextRenderer extends AbstractMapRenderer {
      */
     public String getText() {
         return text;
-    }
-
-    /**
-     * Returns a copy of the point where the renderer begins to render text on a map.
-     */
-    public Point getStartingPoint() {
-        return new Point(startingPoint);
     }
 
     /**
@@ -75,18 +66,6 @@ public class TextRenderer extends AbstractMapRenderer {
         Checks.checkNotNull(text, "Text");
         this.text = text;
     }
-
-    /**
-     * Sets the point this renderer will start rendering from on the map.
-     *
-     * @param startingPoint a new Point.
-     * @throws IllegalArgumentException if the given point cannot be applied to a minecraft map or is null.
-     */
-    public void setStartingPoint(Point startingPoint) {
-        Checks.checkStartingPoint(startingPoint);
-        this.startingPoint = new Point(startingPoint);
-    }
-
     /**
      * Sets the font the rendered text should use.
      *
@@ -146,11 +125,6 @@ public class TextRenderer extends AbstractMapRenderer {
         public TextRenderer build() {
             super.check();
             Checks.checkNotNull(font, "Font");
-            Checks.checkNotNull(startingPoint, "Starting point");
-            Checks.check(startingPoint.x >= 0 && startingPoint.y >= 0, "Negative coordinates are not allowed");
-            Checks.check(startingPoint.x <= ImageTools.MINECRAFT_MAP_SIZE.width
-                            && startingPoint.y <= ImageTools.MINECRAFT_MAP_SIZE.height,
-                    "Starting point is out of minecraft map bounds");
             return new TextRenderer(receivers, precondition, renderOnce, String.join("\n", lines), startingPoint, font);
         }
 
@@ -177,23 +151,6 @@ public class TextRenderer extends AbstractMapRenderer {
          */
         public Builder addLines(String... lines) {
             return addLines(Arrays.asList(lines));
-        }
-
-        /**
-         * Sets the coordinates (via a {@link Point} determining where to begin writing the text on the map.
-         * <p>
-         * This makes a defensive copy of the {@link Point}, so changes to the argument will not have any
-         * effect on this instance.
-         * <p>
-         * This is not required. By default, it will start drawing from the upper left corner (0, 0).
-         *
-         * @param point a {@link Point} representing the coordinates, i.e. where to begin drawing.
-         * @return this.
-         * @see ImageTools#MINECRAFT_MAP_SIZE
-         */
-        public Builder startingPoint(Point point) {
-            this.startingPoint = new Point(point);
-            return this;
         }
 
         /**

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
@@ -115,6 +115,18 @@ public abstract class TextRenderer extends AbstractMapRenderer {
         }
 
         /**
+         * Adds a {@link CharSequence} to the text this renderer will draw.
+         *
+         * @param text A CharSequence, e.g. a String to add. This must include new line characters
+         *             if the result should be multiple lines.
+         * @return this.
+         */
+        public U addText(CharSequence text) {
+            this.text.append(text);
+            return (U) this;
+        }
+
+        /**
          * Sets the font to use for the text.
          * <p>
          * This is not required. By default, it is set to {@link MinecraftFont#Font}.

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
@@ -1,7 +1,6 @@
 package com.github.johnnyjayjay.spigotmaps.rendering;
 
-import com.github.johnnyjayjay.spigotmaps.Checks;
-import com.github.johnnyjayjay.spigotmaps.ImageTools;
+import com.github.johnnyjayjay.spigotmaps.util.Checks;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapFont;
 import org.bukkit.map.MinecraftFont;
@@ -109,7 +108,7 @@ public class TextRenderer extends AbstractMapRenderer {
         }
 
         /**
-         * Builds a new instance of {@link TextRenderer}.
+         * Builds a new instance of {@link TextRenderer} based on the settings made.
          *
          * @return a never-null instance of {@link TextRenderer}.
          * @throws IllegalArgumentException if:

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/TextRenderer.java
@@ -71,6 +71,7 @@ public abstract class TextRenderer extends AbstractMapRenderer {
      *
      * @author Johnny_JayJay (https://github.com/johnnyjayjay)
      */
+    @SuppressWarnings("unchecked")
     protected static abstract class Builder<T extends TextRenderer, U extends Builder<T, U>>
             extends AbstractMapRenderer.Builder<T, U> {
 

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Checks.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Checks.java
@@ -1,4 +1,4 @@
-package com.github.johnnyjayjay.spigotmaps;
+package com.github.johnnyjayjay.spigotmaps.util;
 
 import java.awt.Point;
 

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
@@ -1,4 +1,4 @@
-package com.github.johnnyjayjay.spigotmaps;
+package com.github.johnnyjayjay.spigotmaps.util;
 
 import com.github.johnnyjayjay.spigotmaps.rendering.GifImage;
 import com.github.johnnyjayjay.spigotmaps.rendering.TextRenderer;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
@@ -1,7 +1,7 @@
 package com.github.johnnyjayjay.spigotmaps.util;
 
 import com.github.johnnyjayjay.spigotmaps.rendering.GifImage;
-import com.github.johnnyjayjay.spigotmaps.rendering.TextRenderer;
+import com.github.johnnyjayjay.spigotmaps.rendering.SimpleTextRenderer;
 
 import javax.imageio.ImageIO;
 import java.awt.Color;
@@ -52,7 +52,7 @@ public final class ImageTools {
 
     /**
      * Creates a {@link BufferedImage} with the size of {@link #MINECRAFT_MAP_SIZE}.
-     * The whole image will have one color. This can be used as a background for {@link TextRenderer}s, for example.
+     * The whole image will have one color. This can be used as a background for {@link SimpleTextRenderer}s, for example.
      *
      * @param color the non-{@code null} {@link Color} this image will have.
      * @return a never-null image.


### PR DESCRIPTION
Issue #1 is will be resolved with this PR.
Apart from the new classes `GifImage` and `GifRenderer`, the cropping method in `ImageTools` was fixed and some general changes were made. Every implementation of `AbstractMapRenderer` now inherently has a `startingPoint` field. `ImageTools` and `Checks` were moved to a new `util` package. Some performance improvements were made, such as the removal of unnecessary defensive BufferedImage copies.
The gif functionalities make use of a new dependency: `com.madgag.gif.fmsware`, which can be found [here](https://javalibs.com/artifact/com.madgag/animated-gif-lib).
