### PR TITLE
Fix legacy method issues and ImageTools bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Then add `example-plugin-1.0-TEST.jar` (found in `build/libs`) to your plugins f
 ```xml
 <repositories>
     <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
+        <id>jcenter</id>
+        <url>https://jcenter.bintray.com/</url>
     </repository>
  </repositories>
 
@@ -40,7 +40,7 @@ Then add `example-plugin-1.0-TEST.jar` (found in `build/libs`) to your plugins f
     <dependency>
         <groupId>com.github.johnnyjayjay</groupId>
         <artifactId>spigot-maps</artifactId>
-        <version>2.0</version>
+        <version>2.1</version>
     </dependency>
 </dependencies>
 ```
@@ -49,13 +49,11 @@ Then add `example-plugin-1.0-TEST.jar` (found in `build/libs`) to your plugins f
 
 ```groovy
 repositories {
-    maven {
-        url "https://jitpack.io"
-    }
+    jcenter()
 }
 
 dependencies {
-    implementation "com.github.johnnyjayjay:spigot-maps:2.0"
+    implementation("com.github.johnnyjayjay:spigot-maps:2.1")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.github.johnnyjayjay'
-version '2.0'
+version '2.1'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/InitializationListener.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/InitializationListener.java
@@ -1,5 +1,6 @@
 package com.github.johnnyjayjay.spigotmaps;
 
+import com.github.johnnyjayjay.spigotmaps.util.Compatibility;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -30,7 +31,7 @@ public final class InitializationListener implements Listener {
     @EventHandler
     public void onMapInitialize(MapInitializeEvent event) {
         MapView map = event.getMap();
-        List<MapRenderer> renderers = storage.provide(map.getId());
+        List<MapRenderer> renderers = storage.provide(Compatibility.getId(map));
         if (renderers != null) {
             map.getRenderers().forEach(map::removeRenderer);
             renderers.forEach(map::addRenderer);

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/RenderedMap.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/RenderedMap.java
@@ -26,12 +26,13 @@ public class RenderedMap {
 
     private final MapView view;
     private final MapStorage storage;
+    private final int mapViewId;
 
     private RenderedMap(MapView view, MapStorage storage) {
         this.view = view;
         this.storage = storage;
-        int id = Compatibility.getId(view);
-        view.getRenderers().forEach((renderer) -> storage.store(id, renderer));
+        this.mapViewId = Compatibility.getId(view);
+        view.getRenderers().forEach((renderer) -> storage.store(mapViewId, renderer));
     }
 
     /**
@@ -112,7 +113,11 @@ public class RenderedMap {
     public ItemStack createItemStack(String displayName, String... lore) {
         ItemStack itemStack = new ItemStack(Material.MAP);
         MapMeta mapMeta = (MapMeta) itemStack.getItemMeta();
-        mapMeta.setMapView(view);
+        if (Compatibility.isLegacy()) {
+            itemStack.setDurability((short) mapViewId);
+        } else {
+            mapMeta.setMapView(view);
+        }
         mapMeta.setDisplayName(displayName);
         mapMeta.setLore(lore.length == 0 ? null : Arrays.asList(lore));
         itemStack.setItemMeta(mapMeta);

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/RenderedMap.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/RenderedMap.java
@@ -1,5 +1,7 @@
 package com.github.johnnyjayjay.spigotmaps;
 
+import com.github.johnnyjayjay.spigotmaps.util.Compatibility;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -7,6 +9,9 @@ import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.Arrays;
 import java.util.List;
 
@@ -25,7 +30,8 @@ public class RenderedMap {
     private RenderedMap(MapView view, MapStorage storage) {
         this.view = view;
         this.storage = storage;
-        view.getRenderers().forEach((renderer) -> storage.store(view.getId(), renderer));
+        int id = Compatibility.getId(view);
+        view.getRenderers().forEach((renderer) -> storage.store(id, renderer));
     }
 
     /**

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
@@ -67,6 +67,15 @@ public class GifRenderer extends AbstractMapRenderer {
     }
 
     /**
+     * Returns the {@link GifImage} used by this renderer.
+     *
+     * @return the image
+     */
+    public GifImage getImage() {
+        return image;
+    }
+
+    /**
      * Returns how often the gif will still repeat itself or {@link #REPEAT_FOREVER} if it repeats indefinitely.
      */
     public int getToRepeat() {

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/GifRenderer.java
@@ -101,6 +101,18 @@ public class GifRenderer extends AbstractMapRenderer {
     }
 
     /**
+     * Creates a new {@link GifRenderer} that renders a specific gif for the specified players
+     * or everyone if none are specified.
+     *
+     * @param image   the gif to render.
+     * @param players the players to render for. Must not be {@code null}.
+     * @return a never-null instance of {@link GifRenderer}.
+     */
+    public static GifRenderer create(GifImage image, Player... players) {
+        return builder().gif(image).addPlayers(players).build();
+    }
+
+    /**
      * Creates and returns a new instance of this class' {@link Builder}.
      */
     public static Builder builder() {

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/RenderContext.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/rendering/RenderContext.java
@@ -1,6 +1,7 @@
 package com.github.johnnyjayjay.spigotmaps.rendering;
 
 import com.github.johnnyjayjay.spigotmaps.util.Checks;
+import com.github.johnnyjayjay.spigotmaps.util.Compatibility;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapView;
@@ -19,11 +20,13 @@ public class RenderContext {
     private final MapView mapView;
     private final MapCanvas mapCanvas;
     private final Player player;
+    private final int mapViewId;
 
     private RenderContext(MapView mapView, MapCanvas mapCanvas, Player player) {
         this.mapView = mapView;
         this.mapCanvas = mapCanvas;
         this.player = player;
+        this.mapViewId = Compatibility.getId(mapView);
     }
 
     /**
@@ -68,12 +71,12 @@ public class RenderContext {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RenderContext that = (RenderContext) o;
-        return mapView.getId() == that.mapView.getId()
+        return mapViewId == that.mapViewId
                 && Objects.equals(player, that.player);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mapView.getId(), player);
+        return Objects.hash(mapViewId, player);
     }
 }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
@@ -26,7 +26,9 @@ public final class Compatibility {
         int[] version = Arrays.stream(versionFinder.group().split("\\."))
                 .mapToInt(Integer::parseInt)
                 .toArray();
-        legacy = version[0] < 1 || version[1] < 13 || version[2] < 2;
+        legacy = !(version[0] > 1
+                || (version[0] == 1 && version[1] > 13)
+                || (version[0] == 1 && version[1] == 13 && version[2] >= 2));
 
         MethodType methodType = MethodType.methodType(legacy ? short.class : int.class);
         try {

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
@@ -15,37 +15,37 @@ import java.util.regex.Pattern;
  */
 public final class Compatibility {
 
-  private static final boolean legacy;
-  private static final MethodHandle getId;
+    private static final boolean legacy;
+    private static final MethodHandle getId;
 
-  static {
-    Matcher versionFinder = Pattern.compile("(?<=\\(MC: )\\d+\\.\\d+\\.\\d+(?=\\))").matcher(Bukkit.getVersion());
-    if (!versionFinder.find()) {
-      throw new AssertionError("Could not find MC version in Bukkit.getVersion()");
+    static {
+        Matcher versionFinder = Pattern.compile("(?<=\\(MC: )\\d+\\.\\d+\\.\\d+(?=\\))").matcher(Bukkit.getVersion());
+        if (!versionFinder.find()) {
+            throw new AssertionError("Could not find MC version in Bukkit.getVersion()");
+        }
+        int[] version = Arrays.stream(versionFinder.group().split("\\."))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        legacy = version[0] < 1 || version[1] < 13 || version[2] < 2;
+
+        MethodType methodType = MethodType.methodType(legacy ? short.class : int.class);
+        try {
+            getId = MethodHandles.publicLookup().findVirtual(MapView.class, "getId", methodType);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new AssertionError("MapView#getId() could not be found. This should never happen.");
+        }
     }
-    int[] version = Arrays.stream(versionFinder.group().split("\\."))
-        .mapToInt(Integer::parseInt)
-        .toArray();
-    legacy = version[0] < 1 || version[1] < 13 || version[2] < 2;
 
-    MethodType methodType = MethodType.methodType(legacy ? short.class : int.class);
-    try {
-      getId = MethodHandles.publicLookup().findVirtual(MapView.class, "getId", methodType);
-    } catch (NoSuchMethodException | IllegalAccessException e) {
-      throw new AssertionError("MapView#getId() could not be found. This should never happen.");
+    public static boolean isLegacy() {
+        return legacy;
     }
-  }
 
-  public static boolean isLegacy() {
-    return legacy;
-  }
-
-  public static int getId(MapView map) {
-    try {
-      return ((Number) getId.invoke(map)).intValue();
-    } catch (Throwable throwable) {
-      throw new RuntimeException(throwable);
+    public static int getId(MapView map) {
+        try {
+            return ((Number) getId.invoke(map)).intValue();
+        } catch (Throwable throwable) {
+            throw new RuntimeException(throwable);
+        }
     }
-  }
 
 }

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
@@ -1,0 +1,42 @@
+package com.github.johnnyjayjay.spigotmaps.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.map.MapView;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Arrays;
+
+/**
+ * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
+ */
+public final class Compatibility {
+
+  private static final MethodHandle getId;
+
+  static {
+    MethodType methodType = MethodType.methodType(isLegacy() ? short.class : int.class);
+    try {
+      getId = MethodHandles.publicLookup().findVirtual(MapView.class, "getId", methodType);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new AssertionError("MapView#getId() could not be found. This should never happen.");
+    }
+  }
+
+  public static boolean isLegacy() {
+    int[] version = Arrays.stream(Bukkit.getVersion().split("\\."))
+        .mapToInt(Integer::parseInt)
+        .toArray();
+    return version[0] < 1 || version[1] < 13 || version[2] < 2;
+  }
+
+  public static int getId(MapView map) {
+    try {
+      return ((Number) getId.invoke(map)).intValue();
+    } catch (Throwable throwable) {
+      throw new RuntimeException(throwable);
+    }
+  }
+
+}

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
@@ -23,7 +23,7 @@ public final class Compatibility {
     if (!versionFinder.find()) {
       throw new AssertionError("Could not find MC version in Bukkit.getVersion()");
     }
-    int[] version = Arrays.stream(Bukkit.getVersion().split("\\."))
+    int[] version = Arrays.stream(versionFinder.group().split("\\."))
         .mapToInt(Integer::parseInt)
         .toArray();
     legacy = version[0] < 1 || version[1] < 13 || version[2] < 2;

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
@@ -4,9 +4,7 @@ import com.github.johnnyjayjay.spigotmaps.rendering.GifImage;
 import com.github.johnnyjayjay.spigotmaps.rendering.SimpleTextRenderer;
 
 import javax.imageio.ImageIO;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
@@ -121,7 +119,7 @@ public final class ImageTools {
             );
         }
 
-        int parts = newFrames[0].getImage().getWidth() / MINECRAFT_MAP_SIZE.width;
+        int parts = square(newFrames[0].getImage().getWidth() / MINECRAFT_MAP_SIZE.width);
         GifImage.Frame[][] dividedParts = new GifImage.Frame[parts][newFrames.length];
         for (int i = 0; i < newFrames.length; i++) {
             GifImage.Frame frame = newFrames[i];
@@ -131,6 +129,10 @@ public final class ImageTools {
             }
         }
         return Arrays.stream(dividedParts).map(Arrays::asList).map(GifImage::create).collect(Collectors.toList());
+    }
+
+    private static int square(int x) {
+        return x * x;
     }
 
     /**

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/ImageTools.java
@@ -155,9 +155,9 @@ public final class ImageTools {
         Dimension partSize = MINECRAFT_MAP_SIZE;
         int linearParts = image.getWidth() / partSize.width;
         List<BufferedImage> result = new ArrayList<>(linearParts * linearParts);
-        for (int i = 0; i < linearParts; i++) {
-            for (int j = 0; j < linearParts; j++) {
-                result.add(image.getSubimage(partSize.width * i, partSize.height * i, partSize.width, partSize.height));
+        for (int x = 0; x < linearParts; x++) {
+            for (int y = 0; y < linearParts; y++) {
+                result.add(image.getSubimage(partSize.width * x, partSize.height * y, partSize.width, partSize.height));
             }
         }
         return result.toArray(new BufferedImage[0]);


### PR DESCRIPTION
This PR fixes #6 and similar issues that came up due to the changes in map id handling.

Additionally, it fixes a small, but annoying bug in `ImageTools` that caused the image division to produce incorrect results.

It also adds a method `getImage()` to `GifRenderer` for the purpose of retrieving the source gif after renderer creation.

This will be part of version 2.1.