### PR TITLE
Fix compatibility issues for versions without a third component

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Then add `example-plugin-1.0-TEST.jar` (found in `build/libs`) to your plugins f
 ```xml
 <repositories>
     <repository>
-        <id>jcenter</id>
-        <url>https://jcenter.bintray.com/</url>
+        <url>https://repo.devcord.club/releases</url>
     </repository>
  </repositories>
 
@@ -36,7 +35,7 @@ Then add `example-plugin-1.0-TEST.jar` (found in `build/libs`) to your plugins f
     <dependency>
         <groupId>com.github.johnnyjayjay</groupId>
         <artifactId>spigot-maps</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2</version>
     </dependency>
 </dependencies>
 ```
@@ -45,11 +44,11 @@ Then add `example-plugin-1.0-TEST.jar` (found in `build/libs`) to your plugins f
 
 ```groovy
 repositories {
-    jcenter()
+    maven("https://repo.devcord.club/releases")
 }
 
 dependencies {
-    implementation("com.github.johnnyjayjay:spigot-maps:2.1.1")
+    implementation("com.github.johnnyjayjay:spigot-maps:2.1.2")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,10 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '6.0.0'
-    id 'com.jfrog.bintray' version '1.8.4'
 }
 
 group 'com.github.johnnyjayjay'
-version '2.1.1'
+version '2.1.2'
 
 sourceCompatibility = 1.8
 
@@ -43,56 +42,26 @@ artifacts {
     archives shadowJar
 }
 
-bintray {
-    user = System.getenv("BINTRAY_USER")
-    key = System.getenv("BINTRAY_KEY")
-    publications = ["SpigotMaps"]
-    pkg {
-        version {
-            name = project.version
-            released = new Date()
-        }
-        repo = "spigot-maps"
-        name = "spigot-maps"
-        vcsUrl = "https://github.com/johnnyjayjay/spigot-maps.git"
-    }
-    publish = true
-}
-
-def pomConfig = {
-    licenses {
-        license {
-            name "GNU Lesser General Public License, Version 3"
-            url "https://www.gnu.org/licenses/lgpl-3.0.html"
-        }
-    }
-    developers {
-        developer {
-            id "johnnyjayjay"
-            email "johnnyjayjay02@gmail.com"
-        }
-    }
-    scm {
-        url "https://github.com/johnnyjayjay/spigot-maps"
-    }
-}
-
 publishing {
-    publications {
-        SpigotMaps(MavenPublication) {
-            from components.java
-            artifact sourcesJar
-            artifact javadocJar
-            groupId "com.github.johnnyjayjay"
-            artifactId "spigot-maps"
-            version version.toString()
-            pom.withXml {
-                def root = asNode()
-                root.appendNode("name", "spigot-maps")
-                root.appendNode("description", "A library to simplify the use of customised maps in Spigot")
-                root.appendNode("url", "https://github.com/johnnyjayjay/spigot-maps/")
-                root.children().last() + pomConfig
+    repositories {
+        maven {
+            def repo = "https://repo.devcord.club"
+            def releaseRepo = "$repo/releases"
+            def snapshotRepo = "$repo/snapshots"
+            url = uri(version.toString().endsWith("SNAPSHOT") ? snapshotRepo : releaseRepo)
+
+            credentials {
+                username devcordUsername
+                password devcordPassword
             }
+        }
+    }
+
+    publications {
+        maven(MavenPublication) {
+            artifact(javadocJar)
+            artifact(sourcesJar)
+            from components.java
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
+++ b/src/main/java/com/github/johnnyjayjay/spigotmaps/util/Compatibility.java
@@ -19,7 +19,7 @@ public final class Compatibility {
     private static final MethodHandle getId;
 
     static {
-        Matcher versionFinder = Pattern.compile("(?<=\\(MC: )\\d+\\.\\d+\\.\\d+(?=\\))").matcher(Bukkit.getVersion());
+        Matcher versionFinder = Pattern.compile("(?<=\\(MC: )\\d+\\.\\d+(\\.\\d+)?(?=\\))").matcher(Bukkit.getVersion());
         if (!versionFinder.find()) {
             throw new AssertionError("Could not find MC version in Bukkit.getVersion()");
         }
@@ -28,7 +28,7 @@ public final class Compatibility {
                 .toArray();
         legacy = !(version[0] > 1
                 || (version[0] == 1 && version[1] > 13)
-                || (version[0] == 1 && version[1] == 13 && version[2] >= 2));
+                || (version.length > 2 && version[0] == 1 && version[1] == 13 && version[2] >= 2));
 
         MethodType methodType = MethodType.methodType(legacy ? short.class : int.class);
         try {


### PR DESCRIPTION
This PR fixes an error that occurred when using the library on a server version that only consists of two components, e.g. 1.19, as described by #12 .

It also updates the build/publishing configuration to use a new repository because bintray is dead.